### PR TITLE
German license plate validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 coverage
+phpunit.xml

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ Countries currently supported:
 * Israel (unknown date-now)
 * The Netherlands (1951-now)
 * United Kingdom (1903-now)
+* German (unknown-now)
 
 Other countries will be added in the future
 

--- a/src/Intrepidity/LicensePlate/AbstractLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/AbstractLicensePlate.php
@@ -23,7 +23,7 @@ abstract class AbstractLicensePlate
      * Check an array of regex patterns against the license plate string and give back the matching key if any
      *
      * @param array $patterns Array of regex patterns
-     * @param $licenseplate License plate string
+     * @param string $licenseplate License plate string
      * @return bool|int|string Key for matching regex in the array, or false if none matches.
      */
     protected function checkPatterns(array $patterns, $licenseplate)

--- a/src/Intrepidity/LicensePlate/BelgianLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/BelgianLicensePlate.php
@@ -70,4 +70,14 @@ class BelgianLicensePlate extends AbstractLicensePlate implements LicensePlateIn
                 return substr($licenseplate, 0, 1) . "-" . substr($licenseplate, 1, 3) . "-" . substr($licenseplate, 4, 3);
         }
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'BE';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'BEL';
+    }
 }

--- a/src/Intrepidity/LicensePlate/DutchLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/DutchLicensePlate.php
@@ -123,4 +123,14 @@ class DutchLicensePlate extends AbstractLicensePlate implements LicensePlateInte
     {
         return $this->getSidecode() != false;
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'NL';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'NLD';
+    }
 }

--- a/src/Intrepidity/LicensePlate/FrenchLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/FrenchLicensePlate.php
@@ -88,4 +88,14 @@ class FrenchLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     {
         return $this->getSidecode() != false;
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'FR';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'FRA';
+    }
 }

--- a/src/Intrepidity/LicensePlate/GermanLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/GermanLicensePlate.php
@@ -298,4 +298,14 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
         }
         return $parts;
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'DE';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'DEU';
+    }
 }

--- a/src/Intrepidity/LicensePlate/GermanLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/GermanLicensePlate.php
@@ -147,7 +147,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
                 return $licenseplate[0] . "-" . $licenseplate[1];
 
             case self::SIDE_CODE_CORPS_DIPLOMATIC:
-                $parts = $this->getLicePlateParts($original_transformed_licenseplate);
+                $parts = $this->getLicensePlateParts($original_transformed_licenseplate);
                 if (count($parts) === 3 && $parts[0] === '0')
                 {
                     $second_part_length = strlen($parts[1]);
@@ -284,7 +284,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
             substr($licenseplate, $middle_part_length + $district_length);
     }
 
-    private function getLicePlateParts($original_transformed_licenseplate)
+    private function getLicensePlateParts($original_transformed_licenseplate)
     {
         $parts = array();
         $exploded_by_dash = explode('-', $original_transformed_licenseplate);

--- a/src/Intrepidity/LicensePlate/GermanLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/GermanLicensePlate.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Intrepidity\LicensePlate;
+
+
+/**
+ * German license plate formatter and validator
+ *
+ * Class GermanLicensePlate
+ * @package Intrepidity\LicensePlate
+ */
+class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInterface
+{
+
+    const SIDE_CODE_POLITICAL_HEADS = '0';
+    const SIDE_CODE_CORPS_DIPLOMATIC = 'CD';
+    const SIDE_CODE_AMERICAN_FORCES = 'AF';
+    const SIDE_CODE_SPECIAL_TRANSPORT = 'AG';
+    const SIDE_CODE_FEDERAL_POLICE = 'BG';
+    const SIDE_CODE_TECHNICAL_RELIEF = 'THW';
+    const SIDE_CODE_NATO = 'X';
+    const SIDE_CODE_ARMY = 'Y';
+
+    const DISCTRICTS = array(
+        'A','AA','AB','ABG','ABI','AC','AE','AD','AF','AIC','AK','ALF','AM','AN','ANA','ANK','AÖ','AP','APD','ARN','ART','AS','ASL','ASZ','AT','AU','AUR','AW','AZ','AZE',
+        'B','BA','BAD','BAR','BB','BBG','BC','BCH','BD','BED','BER','BF','BGL','BI','BID','BIN','BIR','BIT','BIW','BK','BKS','BL','BLB','BLK','BM','BN','BNA','BO','BÖ','BOR','BOT','BRA','BRB','BRG','BRL','BRV','BS','BT','BTF','BÜD','BÜS','BÜZ','BW','BWL','BYL','BZ',
+        'C','CA','CAS','CB','CE','CHA','CLP','CLZ','CO','COC','COE','CUX','CW',
+        'D','DA','DAH','DAN','DAU','DB','DBR','DD','DE','DEG','DEL','DGF','DH','DI','DIN','DL','DLG','DM','DN','DO','DON','DU','DÜW','DW','DZ',
+        'E','EA','EB','EBE','ECK','ED','EE','EF','EH','EI','EIC','EIL','EIN','EIS','EL','EM','EMD','EMS','EN','ER','ERB','ERH','ERZ','ES','ESW','EU','EW',
+        'F','FB','FD','FDS','FF','FFB','FG','FI','FL','FLO','FN','FO','FOR','FR','FRG','FRI','FRW','FS','FT','FTL','FÜ',
+        'G','GA','GAP','GC','GD','GDB','GE','GER','GEO','GF','GG','GHA','GHC','GI','GL','GLA','GM','GMN','GN','GNT','GÖ','GOA','GP','GR','GRH','GRZ','GS','GT','GTH','GUB','GÜ','GVM','GW','GZ',
+        'H','HA','HAL','HAM','HAS','HB','HBN','HBS','HC','HCH','HD','HDH','HDL','HE','HEF','HEI', 'HEL','HER','HET','HF','HG','HGN','HGW','HH','HHM','HI','HIG','HK','HK','HL','HM','HMÜ','HN','HO','HOG','HOL','HOM','HOT','HP','HR','HRO','HS','HSK','HST','HU','HVL','HWI','HX','HY','HZ',
+        'IGB','IK','IL','IN','IZ',
+        'J','JE','JL','JÜL',
+        'K','KA','KB','KC','KE','KEH','KF','KG','KH','KI','KIB','KL','KLE','KLZ','KM','KN','KO','KÖT','KR','KS','KT','KU','KÜN','KUS','KY','KYF',
+        'L','LA','LAU','LB','LBS','LBZ','LD','LDK','LDS','LEO','LER','LEV','LG','LI','LIF','LIP','LL','LM','LÖ','LÖB','LOS','LP','LRO','LSA','LSN','LSZ','LU','LUN','LWL',
+        'M','MA','MAB','MB','MC','MD','ME','MEI','MEK','MG','MGN','MH','MHL','MI','MIL','MKK','ML','MK','MM','MN','MO','MOL','MOS','MQ','MR','MS','MSH','MSP','MST','MTK','MTL','MÜ','MÜR','MVL','MW','MYK','MZ','MZG',
+        'N','NB','ND','NDH','NE','NEA','NEB','NES','NEW','NF','NH','NI','NK','NL','NM','NMB','NMS','NOH','NOL','NOM','NOR','NP','NR','NRW','NU','NVP','NW','NWM','NY','NZ',
+        'OA','OAL','OB','OBG','OC','OCH','OD','OE','OF','OG','OH','OHA','OHV','OHZ','OK','OL','OPR','OS','OSL','OVL','OVP',
+        'P','PA','PAF','PAN','PB','PCH','PE','PF','PI','PIR','PL','PLÖ','PM','PN','PR','PRÜ','PS','PW',
+        'QFT','QLB',
+        'R','RA','RC','RD','RDG','RE','REG','RG','RH','RI','RIE','RL','RM','RO','ROW','RP','RPL','RS','RSL','RT','RÜD','RÜG','RV','RW','RZ',
+        'S','SAB','SAL','SAW','SB','SBK','SC','SCZ','SDH','SDL','SE','SEB','SEE','SFA','SFB','SFT','SG','SGH','SH','SHA','SHG','SHK','SHL','SI','SIG','SIM','SK','SL','SLF','SLK','SLN','SLS','SLÜ','SLZ','SM','SN','SO','SÖM','SOK','SON','SP','SPN','SR','SRB','SRO','ST','STA','STD','STL','SU','SÜW','SW','SZ','SZB',
+        'TBB','TDO','TE','TET','TF','TG','THL','TIR','TO','TÖL','TR','TS','TÜ','TUT',
+        'UE','UEM','UER','UH','UL','UM','UN','USI',
+        'V','VB','VEC','VER','VG','VIE','VK','VR','VS',
+        'W','WAF','WAK','WAN','WAT','WB','WBS','WDA','WE','WEN','WES','WF','WHV','WI','WIL','WIS','WIT','WK','WL','WLG','WM','WMS','WN','WND','WO','WOB','WOH','WR','WSF','WST','WT','WTM','WÜ','WUG','WUN','WUR','WW','WZL',
+        'X',
+        'Y',
+        'Z','ZE','ZEL','ZI','ZP','ZR','ZW','ZZ'
+    );
+
+    /**
+     * Get the sidecode of the license plate
+     *
+     * More info: https://nl.wikipedia.org/wiki/Lijst_van_Duitse_kentekens#Speciale_kentekens (in Dutch)
+     *
+     * @return bool|int|string
+     */
+    public function getSidecode()
+    {
+        $licenseplate = strtoupper(str_replace(array('-', ' '), '', $this->licenseplate));
+        $sidecodes = array();
+
+        $district_regex = '/^('.implode('|',self::DISCTRICTS).')';
+        $default_plate_regex = '[a-zA-Z]{1,2}[\d]{1,4}$/';
+        $default_complete_plate_regex = $district_regex.$default_plate_regex;
+
+        // Special sidecodes
+        $sidecodes[self::SIDE_CODE_POLITICAL_HEADS]    = '/^(0[0-4]{1,1}|1{2,2})$/';             // Political heads
+        $sidecodes[self::SIDE_CODE_CORPS_DIPLOMATIC]   = '/^0[\d]{3,6}$/';                       // Corps diplomatique license plates
+        $sidecodes[self::SIDE_CODE_AMERICAN_FORCES]    = '/^(AD|AF|HK|IF)'.$default_plate_regex; // American forces license plates
+        $sidecodes[self::SIDE_CODE_SPECIAL_TRANSPORT]  = '/^AG'.$default_plate_regex;            // Special transport license plates
+        $sidecodes[self::SIDE_CODE_FEDERAL_POLICE]     = '/^(BG|BP)'.$default_plate_regex;       // German federal police license plates
+        $sidecodes[self::SIDE_CODE_TECHNICAL_RELIEF]   = '/^THW'.$default_plate_regex;           // Federal Agency for Technical Relief license plates
+        $sidecodes[self::SIDE_CODE_NATO]               = '/^X'.$default_plate_regex;             // NATO license plates
+        $sidecodes[self::SIDE_CODE_ARMY]               = '/^Y'.$default_plate_regex;             // Army license plates
+
+
+        // Normal sidecodes
+        $sidecodes[1] =     $default_complete_plate_regex;          // Default: district, 1-2 letters, 1-4 numbers
+
+        return $this->checkPatterns($sidecodes, $licenseplate);
+    }
+
+    /**
+     * Format the license plate
+     *
+     * Example: will output 08-TT-NP for input of 08ttnp
+     *
+     * @param int $sidecode Optional input of sidecode. Automatically determined if omitted
+     * @return string Formatted license plate
+     */
+    public function format($sidecode = 0)
+    {
+        //TODO: find out right format per side code
+        /*if($sidecode === 0)
+        {
+            $sidecode = $this->getSidecode();
+        }
+
+        if(false === $sidecode)
+        {
+            return false;
+        }
+
+        $licenseplate = strtoupper(str_replace('-', '', $this->licenseplate));
+
+        switch($sidecode)
+        {
+            case 'CD':
+                if(strlen($licenseplate) < 6)
+                {
+                    return 'CD-' . substr($licenseplate, 2);
+                }
+                else
+                {
+                    return 'CD-' . substr($licenseplate, 2, 2) . "-" . substr($licenseplate, 4, 2);
+                }
+
+            case 'CDJ':
+                return 'CDJ-' . substr($licenseplate, 3);
+
+            case 'AA':
+                return 'AA-' . substr($licenseplate, 2);
+
+            case 7:
+            case 9:
+                // XX-XXX-X
+                return substr($licenseplate, 0, 2) . '-' . substr($licenseplate, 2, 3) .'-' . substr($licenseplate, 5, 1);
+
+            case 8:
+            case 10:
+                // X-XXX-XX
+                return substr($licenseplate, 0, 1) . '-' . substr($licenseplate, 1, 3) . '-' . substr($licenseplate, 4, 2);
+
+            case 11:
+            case 14:
+                // XXX-XX-X
+                return substr($licenseplate, 0, 3) . '-' . substr($licenseplate, 3, 2) . '-' . substr($licenseplate, 5, 1);
+
+            case 12:
+            case 13:
+                // X-XX-XXX
+                return substr($licenseplate, 0, 1) . '-' . substr($licenseplate, 1, 2) . '-' . substr($licenseplate, 3, 3);
+
+            default:
+                // Sidecodes 1-6: XX-XX-XX
+                return substr($licenseplate, 0, 2) . '-' . substr($licenseplate, 2, 2) . '-' . substr($licenseplate, 4, 2);
+        }*/
+    }
+
+    /**
+     * Tests if the license plate is valid
+     * The license plate is valid if the sidecode can be determined
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->getSidecode() !== false;
+    }
+}

--- a/src/Intrepidity/LicensePlate/GermanLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/GermanLicensePlate.php
@@ -12,6 +12,10 @@ namespace Intrepidity\LicensePlate;
 class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInterface
 {
 
+    //TODO: support BWL, BYL, HEL, LSA, LSN, MVL, NL, NRW, RPL, SAL, SH & THL.
+    //Dutch: https://nl.wikipedia.org/wiki/Lijst_van_Duitse_kentekens#Speciale_kentekens (Most information)
+    //English: https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Germany (Only information regarding NRW)
+
     const SIDE_CODE_POLITICAL_HEADS = 'P';
     const SIDE_CODE_CORPS_DIPLOMATIC = 'CD';
     const SIDE_CODE_AMERICAN_FORCES = 'AF';
@@ -22,40 +26,42 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     const SIDE_CODE_ARMY = 'Y';
     const SIDE_CODE_HISTORICAL = 'H';
     const SIDE_CODE_ELECTRICAL = 'E';
+    const SIDE_CODE_DEFAULT = 1;
 
     const DISCTRICTS = array(
-        'AA','A','AB','ABG','ABI','AC','AE','AD','AF','AIC','AK','ALF','AM','AN','ANA','ANK','AÖ','AP','APD','ARN','ART','AS','ASL','ASZ','AT','AU','AUR','AW','AZ','AZE',
-        'BB','B','BA','BAD','BAR','BBG','BC','BCH','BD','BED','BER','BF','BGL','BI','BID','BIN','BIR','BIT','BIW','BK','BKS','BL','BLB','BLK','BM','BN','BNA','BO','BÖ','BOR','BOT','BRA','BRB','BRG','BRL','BRV','BS','BT','BTF','BÜD','BÜS','BÜZ','BW','BWL','BYL','BZ',
+        'A','AA','AB','ABG','ABI','AC','AE','AD','AF','AIC','AK','ALF','AM','AN','ANA','ANK','AÖ','AP','APD','ARN','ART','AS','ASL','ASZ','AT','AU','AUR','AW','AZ','AZE',
+        'B','BB','BA','BAD','BAR','BBG','BC','BCH','BD','BED','BER','BF','BGL','BI','BID','BIN','BIR','BIT','BIW','BK','BKS','BL','BLB','BLK','BM','BN','BNA','BO','BÖ','BOR','BOT','BRA','BRB','BRG','BRL','BRV','BS','BT','BTF','BÜD','BÜS','BÜZ','BW','BZ',
         'C','CA','CAS','CB','CE','CHA','CLP','CLZ','CO','COC','COE','CUX','CW',
         'D','DA','DAH','DAN','DAU','DB','DBR','DD','DE','DEG','DEL','DGF','DH','DI','DIN','DL','DLG','DM','DN','DO','DON','DU','DÜW','DW','DZ',
-        'EE','E','EA','EB','EBE','ECK','ED','EF','EH','EI','EIC','EIL','EIN','EIS','EL','EM','EMD','EMS','EN','ER','ERB','ERH','ERZ','ES','ESW','EU','EW',
-        'FF','F','FB','FD','FDS','FFB','FG','FI','FL','FLO','FN','FO','FOR','FR','FRG','FRI','FRW','FS','FT','FTL','FÜ',
-        'GG','G','GA','GAP','GC','GD','GDB','GE','GER','GEO','GF','GHA','GHC','GI','GL','GLA','GM','GMN','GN','GNT','GÖ','GOA','GP','GR','GRH','GRZ','GS','GT','GTH','GUB','GÜ','GVM','GW','GZ',
-        'HH','H','HA','HAL','HAM','HAS','HB','HBN','HBS','HC','HCH','HD','HDH','HDL','HE','HEF','HEI', 'HEL','HER','HET','HF','HG','HGN','HGW','HHM','HI','HIG','HK','HK','HL','HM','HMÜ','HN','HO','HOG','HOL','HOM','HOT','HP','HR','HRO','HS','HSK','HST','HU','HVL','HWI','HX','HY','HZ',
+        'E','EE','EA','EB','EBE','ECK','ED','EF','EH','EI','EIC','EIL','EIN','EIS','EL','EM','EMD','EMS','EN','ER','ERB','ERH','ERZ','ES','ESW','EU','EW',
+        'F','FF','FB','FD','FDS','FFB','FG','FI','FL','FLO','FN','FO','FOR','FR','FRG','FRI','FRW','FS','FT','FTL','FÜ',
+        'G','GG','GA','GAP','GC','GD','GDB','GE','GER','GEO','GF','GHA','GHC','GI','GL','GLA','GM','GMN','GN','GNT','GÖ','GOA','GP','GR','GRH','GRZ','GS','GT','GTH','GUB','GÜ','GVM','GW','GZ',
+        'H','HH','HA','HAL','HAM','HAS','HB','HBN','HBS','HC','HCH','HD','HDH','HDL','HE','HEF','HEI','HER','HET','HF','HG','HGN','HGW','HHM','HI','HIG','HK','HK','HL','HM','HMÜ','HN','HO','HOG','HOL','HOM','HOT','HP','HR','HRO','HS','HSK','HST','HU','HVL','HWI','HX','HY','HZ',
         'IGB','IK','IL','IN','IZ',
         'J','JE','JL','JÜL',
         'K','KA','KB','KC','KE','KEH','KF','KG','KH','KI','KIB','KL','KLE','KLZ','KM','KN','KO','KÖT','KR','KS','KT','KU','KÜN','KUS','KY','KYF',
-        'LL','L','LA','LAU','LB','LBS','LBZ','LD','LDK','LDS','LEO','LER','LEV','LG','LI','LIF','LIP','LM','LÖ','LÖB','LOS','LP','LRO','LSA','LSN','LSZ','LU','LUN','LWL',
-        'MM','M','MA','MAB','MB','MC','MD','ME','MEI','MEK','MG','MGN','MH','MHL','MI','MIL','MKK','ML','MK','MN','MO','MOL','MOS','MQ','MR','MS','MSH','MSP','MST','MTK','MTL','MÜ','MÜR','MVL','MW','MYK','MZ','MZG',
-        'N','NB','ND','NDH','NE','NEA','NEB','NES','NEW','NF','NH','NI','NK','NL','NM','NMB','NMS','NOH','NOL','NOM','NOR','NP','NR','NRW','NU','NVP','NW','NWM','NY','NZ',
+        'L','LL','LA','LAU','LB','LBS','LBZ','LD','LDK','LDS','LEO','LER','LEV','LG','LI','LIF','LIP','LM','LÖ','LÖB','LOS','LP','LRO','LSZ','LU','LUN','LWL',
+        'M','MM','MA','MAB','MB','MC','MD','ME','MEI','MEK','MG','MGN','MH','MHL','MI','MIL','MKK','ML','MK','MN','MO','MOL','MOS','MQ','MR','MS','MSH','MSP','MST','MTK','MTL','MÜ','MÜR','MW','MYK','MZ','MZG',
+        'N','NB','ND','NDH','NE','NEA','NEB','NES','NEW','NF','NH','NI','NK','NM','NMB','NMS','NOH','NOL','NOM','NOR','NP','NR','NU','NVP','NW','NWM','NY','NZ',
         'OA','OAL','OB','OBG','OC','OCH','OD','OE','OF','OG','OH','OHA','OHV','OHZ','OK','OL','OPR','OS','OSL','OVL','OVP',
         'P','PA','PAF','PAN','PB','PCH','PE','PF','PI','PIR','PL','PLÖ','PM','PN','PR','PRÜ','PS','PW',
         'QFT','QLB',
-        'R','RA','RC','RD','RDG','RE','REG','RG','RH','RI','RIE','RL','RM','RO','ROW','RP','RPL','RS','RSL','RT','RÜD','RÜG','RV','RW','RZ',
-        'S','SAB','SAL','SAW','SB','SBK','SC','SCZ','SDH','SDL','SE','SEB','SEE','SFA','SFB','SFT','SG','SGH','SH','SHA','SHG','SHK','SHL','SI','SIG','SIM','SK','SL','SLF','SLK','SLN','SLS','SLÜ','SLZ','SM','SN','SO','SÖM','SOK','SON','SP','SPN','SR','SRB','SRO','ST','STA','STD','STL','SU','SÜW','SW','SZ','SZB',
-        'TBB','TDO','TE','TET','TF','TG','THL','TIR','TO','TÖL','TR','TS','TÜ','TUT',
+        'R','RA','RC','RD','RDG','RE','REG','RG','RH','RI','RIE','RL','RM','RO','ROW','RP','RS','RSL','RT','RÜD','RÜG','RV','RW','RZ',
+        'S','SAB','SAW','SB','SBK','SC','SCZ','SDH','SDL','SE','SEB','SEE','SFA','SFB','SFT','SG','SGH','SHA','SHG','SHK','SHL','SI','SIG','SIM','SK','SL','SLF','SLK','SLN','SLS','SLÜ','SLZ','SM','SN','SO','SÖM','SOK','SON','SP','SPN','SR','SRB','SRO','ST','STA','STD','STL','SU','SÜW','SW','SZ','SZB',
+        'TBB','TDO','TE','TET','TF','TG','TIR','TO','TÖL','TR','TS','TÜ','TUT',
         'UE','UEM','UER','UH','UL','UM','UN','USI',
         'V','VB','VEC','VER','VG','VIE','VK','VR','VS',
-        'WW','W','WAF','WAK','WAN','WAT','WB','WBS','WDA','WE','WEN','WES','WF','WHV','WI','WIL','WIS','WIT','WK','WL','WLG','WM','WMS','WN','WND','WO','WOB','WOH','WR','WSF','WST','WT','WTM','WÜ','WUG','WUN','WUR','WZL',
+        'W','WW','WAF','WAK','WAN','WAT','WB','WBS','WDA','WE','WEN','WES','WF','WHV','WI','WIL','WIS','WIT','WK','WL','WLG','WM','WMS','WN','WND','WO','WOB','WOH','WR','WSF','WST','WT','WTM','WÜ','WUG','WUN','WUR','WZL',
         'X',
         'Y',
-        'ZZ', 'Z','ZE','ZEL','ZI','ZP','ZR','ZW'
+        'Z','ZZ','ZE','ZEL','ZI','ZP','ZR','ZW'
     );
 
     private $district_regex;
     private $core_default_plate_regex;
     private $default_plate_regex;
     private $default_complete_plate_regex;
+    private $original_licenseplate;
 
     public function __construct($licenseplate)
     {
@@ -63,6 +69,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
         $this->core_default_plate_regex = '[a-zA-Z]{1,2}[\d]{1,4}';
         $this->default_plate_regex = $this->core_default_plate_regex.'$/';
         $this->default_complete_plate_regex = $this->district_regex.$this->default_plate_regex;
+        $this->original_licenseplate = trim($licenseplate);
         parent::__construct($licenseplate);
     }
 
@@ -75,7 +82,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
      */
     public function getSidecode()
     {
-        $licenseplate = strtoupper(str_replace(array('-', ' '), '', $this->licenseplate));
+        $licenseplate = strtoupper(trim(str_replace(array('-', ' '), '', $this->licenseplate)));
         if (strlen($licenseplate) > 8)
         {
             return false;
@@ -88,15 +95,14 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
         $sidecodes[self::SIDE_CODE_AMERICAN_FORCES]    = '/^(AD|AF|HK|IF)'.$this->default_plate_regex; // American forces license plates
         $sidecodes[self::SIDE_CODE_SPECIAL_TRANSPORT]  = '/^AG'.$this->default_plate_regex;            // Special transport license plates
         $sidecodes[self::SIDE_CODE_FEDERAL_POLICE]     = '/^(BG|BP)[\d]{3,6}$/';                       // German federal police license plates
-        $sidecodes[self::SIDE_CODE_TECHNICAL_RELIEF]   = '/^THW'.$this->default_plate_regex;           // Federal Agency for Technical Relief license plates
-        $sidecodes[self::SIDE_CODE_NATO]               = '/^X'.$this->default_plate_regex;             // NATO license plates
-        $sidecodes[self::SIDE_CODE_ARMY]               = '/^Y'.$this->default_plate_regex;             // Army license plates
-        $sidecodes[self::SIDE_CODE_HISTORICAL]         = '/^'.$this->core_default_plate_regex.'H$/';   // Historical vehicles license plates
-        $sidecodes[self::SIDE_CODE_ELECTRICAL]         = '/^'.$this->core_default_plate_regex.'E$/';   // Electric vehicles license plates
-
+        $sidecodes[self::SIDE_CODE_TECHNICAL_RELIEF]   = '/^THW(8|9)[\d]{3,4}$/';                      // Federal Agency for Technical Relief license plates
+        $sidecodes[self::SIDE_CODE_NATO]               = '/^X[\d]{4,4}$/';                             // NATO license plates
+        $sidecodes[self::SIDE_CODE_ARMY]               = '/^Y[\d]{5,6}$/';                             // Army license plates
+        $sidecodes[self::SIDE_CODE_HISTORICAL]         = $this->district_regex.$this->core_default_plate_regex.'H$/';   // Historical vehicles license plates
+        $sidecodes[self::SIDE_CODE_ELECTRICAL]         = $this->district_regex.$this->core_default_plate_regex.'E$/';   // Electric vehicles license plates
 
         // Normal sidecodes
-        $sidecodes[1] =     $this->default_complete_plate_regex;          // Default: district, 1-2 letters, 1-4 numbers
+        $sidecodes[self::SIDE_CODE_DEFAULT] =     $this->default_complete_plate_regex;          // Default: district, 1-2 letters, 1-4 numbers
 
         return $this->checkPatterns($sidecodes, $licenseplate);
     }
@@ -116,41 +122,41 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
         {
             $sidecode = $this->getSidecode();
         }
-
         if(false === $sidecode)
         {
             return false;
         }
 
-        $licenseplate = strtoupper(str_replace(array('-', ' '), '', $this->licenseplate));
+        $original_transformed_licenseplate = strtoupper($this->original_licenseplate);
+        $licenseplate = str_replace(array('-', ' '), '', $original_transformed_licenseplate);
 
         switch($sidecode)
         {
-            case 1:
-                $matches = array();
-                $longest_first_part_length = 0;
-                preg_match($this->district_regex.'/', $licenseplate, $matches);
+            case self::SIDE_CODE_DEFAULT:
+                return $this->formatDefaultLicensePlate($original_transformed_licenseplate, $licenseplate);
 
-                foreach($matches as $match)
-                {
-                    if (strlen($match) > $longest_first_part_length)
-                    {
-                        $longest_first_part_length = strlen($match);
-                    }
-                }
+            case self::SIDE_CODE_ELECTRICAL:
+                $formatted_license_plate = $this->formatDefaultLicensePlate(substr($original_transformed_licenseplate,0, -1), substr($licenseplate,0, -1)).'E';
+                return $formatted_license_plate;
 
-                $number_matches = array();
-                preg_match('/\d/', $licenseplate, $number_matches, PREG_OFFSET_CAPTURE);
-                $middle_part_length = $number_matches[0][1] - $longest_first_part_length;
-
-                return substr($licenseplate,0, $longest_first_part_length).' '.
-                    substr($licenseplate, $longest_first_part_length, $middle_part_length).' '.
-                    substr($licenseplate, $middle_part_length + $longest_first_part_length);
+            case self::SIDE_CODE_HISTORICAL:
+                $formatted_license_plate = $this->formatDefaultLicensePlate(substr($original_transformed_licenseplate,0, -1), substr($licenseplate,0, -1)).'H';
+                return $formatted_license_plate;
 
             case self::SIDE_CODE_POLITICAL_HEADS:
                 return $licenseplate[0] . "-" . $licenseplate[1];
 
             case self::SIDE_CODE_CORPS_DIPLOMATIC:
+                $parts = $this->getLicePlateParts($original_transformed_licenseplate);
+                if (count($parts) === 3 && $parts[0] === '0')
+                {
+                    $second_part_length = strlen($parts[1]);
+                    $third_part_length = strlen($parts[2]);
+                    if ($second_part_length >= 2 && $second_part_length <= 3 && $third_part_length >= 1 && $third_part_length <= 3)
+                    {
+                        return implode('-', $parts);
+                    }
+                }
                 if (strlen($licenseplate) > 6)
                 {
                     return $licenseplate[0].'-'.substr($licenseplate, 1, 3).'-'.substr($licenseplate, 4);
@@ -158,13 +164,30 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
                 return $licenseplate[0].'-'.substr($licenseplate, 1, 2).'-'.substr($licenseplate, 3);
 
             case self::SIDE_CODE_AMERICAN_FORCES:
-
                 $number_matches = array();
                 preg_match('/\d/', $licenseplate, $number_matches, PREG_OFFSET_CAPTURE);
                 $first_number_index = $number_matches[0][1];
 
                 return substr($licenseplate, 0,2).' '.substr($licenseplate, 2, $first_number_index-2).' '. substr($licenseplate, $first_number_index);
 
+            case self::SIDE_CODE_TECHNICAL_RELIEF:
+                return substr($licenseplate, 0,3).' '.substr($licenseplate, 3);
+
+            case self::SIDE_CODE_FEDERAL_POLICE:
+                return substr($licenseplate, 0,2).' '.substr($licenseplate, 2, 2).'-'.substr($licenseplate, 4);
+
+            case self::SIDE_CODE_ARMY:
+                if (strlen($licenseplate) === 6)
+                {
+                    return 'Y-'.substr($licenseplate, 1, 2).' '.substr($licenseplate, 3);
+                }
+                return 'Y-'.substr($licenseplate, 1, 3).' '.substr($licenseplate, 4);
+
+            case self::SIDE_CODE_NATO:
+                return 'X-'.substr($licenseplate,1);
+
+            case self::SIDE_CODE_SPECIAL_TRANSPORT:
+                //TODO: implement, need more information
             default:
                 // Sidecodes without any known format
                 return $this->licenseplate;
@@ -180,5 +203,99 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     public function isValid()
     {
         return $this->getSidecode() !== false;
+    }
+
+    private function formatDefaultLicensePlate($original_transformed_licenseplate, $licenseplate)
+    {
+        $delimiter_position = $this->getDelimiterPositionFromLicensePlate($original_transformed_licenseplate);
+        if ($delimiter_position !== false)
+        {
+            $formatted_license_plate = $this->getFormattedLicensePlateForLicensePlateWithFormat($original_transformed_licenseplate, $licenseplate, $delimiter_position);
+            if (is_string($formatted_license_plate))
+            {
+                return $formatted_license_plate;
+            }
+        }
+
+        return $this->getFormattedLicensePlateForLicensePlateWithoutFormat($licenseplate);
+    }
+
+    private function getDelimiterPositionFromLicensePlate($original_transformed_licenseplate, $start = 0, $length = 4)
+    {
+        $dash_position = strpos(substr($original_transformed_licenseplate,$start,$length), '-');
+        if ($dash_position !== false)
+        {
+            return $dash_position;
+        }
+        return strpos(substr($original_transformed_licenseplate,$start,$length), ' ');
+    }
+
+    private function getFormattedLicensePlateForLicensePlateWithFormat($original_transformed_licenseplate, $licenseplate, $delimiter_position)
+    {
+        $district = substr($original_transformed_licenseplate, 0,$delimiter_position);
+        $district_length = strlen($district);
+
+        $letters_only = preg_replace("/[^a-zA-Z]+/", "", $original_transformed_licenseplate);
+        $middle_part = substr($letters_only,$district_length);
+        $middle_part_length = strlen($middle_part);
+
+        if ($middle_part_length <= 2 && strlen($letters_only) > $district_length)
+        {
+            return $district.' '.$middle_part.' '.substr($licenseplate, $district_length + $middle_part_length);
+        }
+        return false;
+    }
+
+    private function getFormattedLicensePlateForLicensePlateWithoutFormat($licenseplate)
+    {
+        $possible_districts = array();
+        $letters_only = $result = preg_replace("/[^a-zA-Z]+/", "", $licenseplate);
+        $letters_only_length = strlen($letters_only);
+        $start = 0;
+        if ($letters_only_length > 2)
+        {
+            $start = $letters_only_length - 2;
+        }
+        for($i = $start; $i < $letters_only_length; $i ++)
+        {
+            $district = substr($letters_only,0, $i);
+            if (preg_match($this->district_regex.'$/', $district) === 1)
+            {
+                if (strlen($district) >= ($letters_only_length-2))
+                {
+                    $possible_districts[] = $district;
+                }
+                if (count($possible_districts) > 2)
+                {
+                    array_shift($possible_districts);
+                }
+            }
+        }
+        //always prioritise the shortest possible (most chance to be right since it's a bigger city).
+        $district = $possible_districts[0];
+        $district_length = strlen($district);
+
+        $number_matches = array();
+        preg_match('/\d/', $licenseplate, $number_matches, PREG_OFFSET_CAPTURE);
+        $middle_part_length = $number_matches[0][1] - $district_length;
+
+        return $district.' '.
+            substr($licenseplate, $district_length, $middle_part_length).' '.
+            substr($licenseplate, $middle_part_length + $district_length);
+    }
+
+    private function getLicePlateParts($original_transformed_licenseplate)
+    {
+        $parts = array();
+        $exploded_by_dash = explode('-', $original_transformed_licenseplate);
+        foreach($exploded_by_dash as $parted_by_dash)
+        {
+            $exploded_by_space = explode(' ', $parted_by_dash);
+            foreach ($exploded_by_space as $parted_by_space)
+            {
+                $parts[] = $parted_by_space;
+            }
+        }
+        return $parts;
     }
 }

--- a/src/Intrepidity/LicensePlate/GermanLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/GermanLicensePlate.php
@@ -12,7 +12,7 @@ namespace Intrepidity\LicensePlate;
 class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInterface
 {
 
-    const SIDE_CODE_POLITICAL_HEADS = '0';
+    const SIDE_CODE_POLITICAL_HEADS = 'P';
     const SIDE_CODE_CORPS_DIPLOMATIC = 'CD';
     const SIDE_CODE_AMERICAN_FORCES = 'AF';
     const SIDE_CODE_SPECIAL_TRANSPORT = 'AG';
@@ -20,21 +20,23 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     const SIDE_CODE_TECHNICAL_RELIEF = 'THW';
     const SIDE_CODE_NATO = 'X';
     const SIDE_CODE_ARMY = 'Y';
+    const SIDE_CODE_HISTORICAL = 'H';
+    const SIDE_CODE_ELECTRICAL = 'E';
 
     const DISCTRICTS = array(
-        'A','AA','AB','ABG','ABI','AC','AE','AD','AF','AIC','AK','ALF','AM','AN','ANA','ANK','AÖ','AP','APD','ARN','ART','AS','ASL','ASZ','AT','AU','AUR','AW','AZ','AZE',
-        'B','BA','BAD','BAR','BB','BBG','BC','BCH','BD','BED','BER','BF','BGL','BI','BID','BIN','BIR','BIT','BIW','BK','BKS','BL','BLB','BLK','BM','BN','BNA','BO','BÖ','BOR','BOT','BRA','BRB','BRG','BRL','BRV','BS','BT','BTF','BÜD','BÜS','BÜZ','BW','BWL','BYL','BZ',
+        'AA','A','AB','ABG','ABI','AC','AE','AD','AF','AIC','AK','ALF','AM','AN','ANA','ANK','AÖ','AP','APD','ARN','ART','AS','ASL','ASZ','AT','AU','AUR','AW','AZ','AZE',
+        'BB','B','BA','BAD','BAR','BBG','BC','BCH','BD','BED','BER','BF','BGL','BI','BID','BIN','BIR','BIT','BIW','BK','BKS','BL','BLB','BLK','BM','BN','BNA','BO','BÖ','BOR','BOT','BRA','BRB','BRG','BRL','BRV','BS','BT','BTF','BÜD','BÜS','BÜZ','BW','BWL','BYL','BZ',
         'C','CA','CAS','CB','CE','CHA','CLP','CLZ','CO','COC','COE','CUX','CW',
         'D','DA','DAH','DAN','DAU','DB','DBR','DD','DE','DEG','DEL','DGF','DH','DI','DIN','DL','DLG','DM','DN','DO','DON','DU','DÜW','DW','DZ',
-        'E','EA','EB','EBE','ECK','ED','EE','EF','EH','EI','EIC','EIL','EIN','EIS','EL','EM','EMD','EMS','EN','ER','ERB','ERH','ERZ','ES','ESW','EU','EW',
-        'F','FB','FD','FDS','FF','FFB','FG','FI','FL','FLO','FN','FO','FOR','FR','FRG','FRI','FRW','FS','FT','FTL','FÜ',
-        'G','GA','GAP','GC','GD','GDB','GE','GER','GEO','GF','GG','GHA','GHC','GI','GL','GLA','GM','GMN','GN','GNT','GÖ','GOA','GP','GR','GRH','GRZ','GS','GT','GTH','GUB','GÜ','GVM','GW','GZ',
-        'H','HA','HAL','HAM','HAS','HB','HBN','HBS','HC','HCH','HD','HDH','HDL','HE','HEF','HEI', 'HEL','HER','HET','HF','HG','HGN','HGW','HH','HHM','HI','HIG','HK','HK','HL','HM','HMÜ','HN','HO','HOG','HOL','HOM','HOT','HP','HR','HRO','HS','HSK','HST','HU','HVL','HWI','HX','HY','HZ',
+        'EE','E','EA','EB','EBE','ECK','ED','EF','EH','EI','EIC','EIL','EIN','EIS','EL','EM','EMD','EMS','EN','ER','ERB','ERH','ERZ','ES','ESW','EU','EW',
+        'FF','F','FB','FD','FDS','FFB','FG','FI','FL','FLO','FN','FO','FOR','FR','FRG','FRI','FRW','FS','FT','FTL','FÜ',
+        'GG','G','GA','GAP','GC','GD','GDB','GE','GER','GEO','GF','GHA','GHC','GI','GL','GLA','GM','GMN','GN','GNT','GÖ','GOA','GP','GR','GRH','GRZ','GS','GT','GTH','GUB','GÜ','GVM','GW','GZ',
+        'HH','H','HA','HAL','HAM','HAS','HB','HBN','HBS','HC','HCH','HD','HDH','HDL','HE','HEF','HEI', 'HEL','HER','HET','HF','HG','HGN','HGW','HHM','HI','HIG','HK','HK','HL','HM','HMÜ','HN','HO','HOG','HOL','HOM','HOT','HP','HR','HRO','HS','HSK','HST','HU','HVL','HWI','HX','HY','HZ',
         'IGB','IK','IL','IN','IZ',
         'J','JE','JL','JÜL',
         'K','KA','KB','KC','KE','KEH','KF','KG','KH','KI','KIB','KL','KLE','KLZ','KM','KN','KO','KÖT','KR','KS','KT','KU','KÜN','KUS','KY','KYF',
-        'L','LA','LAU','LB','LBS','LBZ','LD','LDK','LDS','LEO','LER','LEV','LG','LI','LIF','LIP','LL','LM','LÖ','LÖB','LOS','LP','LRO','LSA','LSN','LSZ','LU','LUN','LWL',
-        'M','MA','MAB','MB','MC','MD','ME','MEI','MEK','MG','MGN','MH','MHL','MI','MIL','MKK','ML','MK','MM','MN','MO','MOL','MOS','MQ','MR','MS','MSH','MSP','MST','MTK','MTL','MÜ','MÜR','MVL','MW','MYK','MZ','MZG',
+        'LL','L','LA','LAU','LB','LBS','LBZ','LD','LDK','LDS','LEO','LER','LEV','LG','LI','LIF','LIP','LM','LÖ','LÖB','LOS','LP','LRO','LSA','LSN','LSZ','LU','LUN','LWL',
+        'MM','M','MA','MAB','MB','MC','MD','ME','MEI','MEK','MG','MGN','MH','MHL','MI','MIL','MKK','ML','MK','MN','MO','MOL','MOS','MQ','MR','MS','MSH','MSP','MST','MTK','MTL','MÜ','MÜR','MVL','MW','MYK','MZ','MZG',
         'N','NB','ND','NDH','NE','NEA','NEB','NES','NEW','NF','NH','NI','NK','NL','NM','NMB','NMS','NOH','NOL','NOM','NOR','NP','NR','NRW','NU','NVP','NW','NWM','NY','NZ',
         'OA','OAL','OB','OBG','OC','OCH','OD','OE','OF','OG','OH','OHA','OHV','OHZ','OK','OL','OPR','OS','OSL','OVL','OVP',
         'P','PA','PAF','PAN','PB','PCH','PE','PF','PI','PIR','PL','PLÖ','PM','PN','PR','PRÜ','PS','PW',
@@ -44,11 +46,25 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
         'TBB','TDO','TE','TET','TF','TG','THL','TIR','TO','TÖL','TR','TS','TÜ','TUT',
         'UE','UEM','UER','UH','UL','UM','UN','USI',
         'V','VB','VEC','VER','VG','VIE','VK','VR','VS',
-        'W','WAF','WAK','WAN','WAT','WB','WBS','WDA','WE','WEN','WES','WF','WHV','WI','WIL','WIS','WIT','WK','WL','WLG','WM','WMS','WN','WND','WO','WOB','WOH','WR','WSF','WST','WT','WTM','WÜ','WUG','WUN','WUR','WW','WZL',
+        'WW','W','WAF','WAK','WAN','WAT','WB','WBS','WDA','WE','WEN','WES','WF','WHV','WI','WIL','WIS','WIT','WK','WL','WLG','WM','WMS','WN','WND','WO','WOB','WOH','WR','WSF','WST','WT','WTM','WÜ','WUG','WUN','WUR','WZL',
         'X',
         'Y',
-        'Z','ZE','ZEL','ZI','ZP','ZR','ZW','ZZ'
+        'ZZ', 'Z','ZE','ZEL','ZI','ZP','ZR','ZW'
     );
+
+    private $district_regex;
+    private $core_default_plate_regex;
+    private $default_plate_regex;
+    private $default_complete_plate_regex;
+
+    public function __construct($licenseplate)
+    {
+        $this->district_regex = '/^('.implode('|',self::DISCTRICTS).')';
+        $this->core_default_plate_regex = '[a-zA-Z]{1,2}[\d]{1,4}';
+        $this->default_plate_regex = $this->core_default_plate_regex.'$/';
+        $this->default_complete_plate_regex = $this->district_regex.$this->default_plate_regex;
+        parent::__construct($licenseplate);
+    }
 
     /**
      * Get the sidecode of the license plate
@@ -60,25 +76,27 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     public function getSidecode()
     {
         $licenseplate = strtoupper(str_replace(array('-', ' '), '', $this->licenseplate));
+        if (strlen($licenseplate) > 8)
+        {
+            return false;
+        }
         $sidecodes = array();
 
-        $district_regex = '/^('.implode('|',self::DISCTRICTS).')';
-        $default_plate_regex = '[a-zA-Z]{1,2}[\d]{1,4}$/';
-        $default_complete_plate_regex = $district_regex.$default_plate_regex;
-
         // Special sidecodes
-        $sidecodes[self::SIDE_CODE_POLITICAL_HEADS]    = '/^(0[0-4]{1,1}|1{2,2})$/';             // Political heads
-        $sidecodes[self::SIDE_CODE_CORPS_DIPLOMATIC]   = '/^0[\d]{3,6}$/';                       // Corps diplomatique license plates
-        $sidecodes[self::SIDE_CODE_AMERICAN_FORCES]    = '/^(AD|AF|HK|IF)'.$default_plate_regex; // American forces license plates
-        $sidecodes[self::SIDE_CODE_SPECIAL_TRANSPORT]  = '/^AG'.$default_plate_regex;            // Special transport license plates
-        $sidecodes[self::SIDE_CODE_FEDERAL_POLICE]     = '/^(BG|BP)'.$default_plate_regex;       // German federal police license plates
-        $sidecodes[self::SIDE_CODE_TECHNICAL_RELIEF]   = '/^THW'.$default_plate_regex;           // Federal Agency for Technical Relief license plates
-        $sidecodes[self::SIDE_CODE_NATO]               = '/^X'.$default_plate_regex;             // NATO license plates
-        $sidecodes[self::SIDE_CODE_ARMY]               = '/^Y'.$default_plate_regex;             // Army license plates
+        $sidecodes[self::SIDE_CODE_POLITICAL_HEADS]    = '/^(0[0-4]{1,1}|1{2,2})$/';                   // Political heads
+        $sidecodes[self::SIDE_CODE_CORPS_DIPLOMATIC]   = '/^0[\d]{3,6}$/';                             // Corps diplomatique license plates
+        $sidecodes[self::SIDE_CODE_AMERICAN_FORCES]    = '/^(AD|AF|HK|IF)'.$this->default_plate_regex; // American forces license plates
+        $sidecodes[self::SIDE_CODE_SPECIAL_TRANSPORT]  = '/^AG'.$this->default_plate_regex;            // Special transport license plates
+        $sidecodes[self::SIDE_CODE_FEDERAL_POLICE]     = '/^(BG|BP)[\d]{3,6}$/';                       // German federal police license plates
+        $sidecodes[self::SIDE_CODE_TECHNICAL_RELIEF]   = '/^THW'.$this->default_plate_regex;           // Federal Agency for Technical Relief license plates
+        $sidecodes[self::SIDE_CODE_NATO]               = '/^X'.$this->default_plate_regex;             // NATO license plates
+        $sidecodes[self::SIDE_CODE_ARMY]               = '/^Y'.$this->default_plate_regex;             // Army license plates
+        $sidecodes[self::SIDE_CODE_HISTORICAL]         = '/^'.$this->core_default_plate_regex.'H$/';   // Historical vehicles license plates
+        $sidecodes[self::SIDE_CODE_ELECTRICAL]         = '/^'.$this->core_default_plate_regex.'E$/';   // Electric vehicles license plates
 
 
         // Normal sidecodes
-        $sidecodes[1] =     $default_complete_plate_regex;          // Default: district, 1-2 letters, 1-4 numbers
+        $sidecodes[1] =     $this->default_complete_plate_regex;          // Default: district, 1-2 letters, 1-4 numbers
 
         return $this->checkPatterns($sidecodes, $licenseplate);
     }
@@ -86,7 +104,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     /**
      * Format the license plate
      *
-     * Example: will output 08-TT-NP for input of 08ttnp
+     * Example: will output J YA 253 for input of jya253 and FRI ES 807 for fries807
      *
      * @param int $sidecode Optional input of sidecode. Automatically determined if omitted
      * @return string Formatted license plate
@@ -94,7 +112,7 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
     public function format($sidecode = 0)
     {
         //TODO: find out right format per side code
-        /*if($sidecode === 0)
+        if($sidecode === 0)
         {
             $sidecode = $this->getSidecode();
         }
@@ -104,50 +122,53 @@ class GermanLicensePlate extends AbstractLicensePlate implements LicensePlateInt
             return false;
         }
 
-        $licenseplate = strtoupper(str_replace('-', '', $this->licenseplate));
+        $licenseplate = strtoupper(str_replace(array('-', ' '), '', $this->licenseplate));
 
         switch($sidecode)
         {
-            case 'CD':
-                if(strlen($licenseplate) < 6)
+            case 1:
+                $matches = array();
+                $longest_first_part_length = 0;
+                preg_match($this->district_regex.'/', $licenseplate, $matches);
+
+                foreach($matches as $match)
                 {
-                    return 'CD-' . substr($licenseplate, 2);
+                    if (strlen($match) > $longest_first_part_length)
+                    {
+                        $longest_first_part_length = strlen($match);
+                    }
                 }
-                else
+
+                $number_matches = array();
+                preg_match('/\d/', $licenseplate, $number_matches, PREG_OFFSET_CAPTURE);
+                $middle_part_length = $number_matches[0][1] - $longest_first_part_length;
+
+                return substr($licenseplate,0, $longest_first_part_length).' '.
+                    substr($licenseplate, $longest_first_part_length, $middle_part_length).' '.
+                    substr($licenseplate, $middle_part_length + $longest_first_part_length);
+
+            case self::SIDE_CODE_POLITICAL_HEADS:
+                return $licenseplate[0] . "-" . $licenseplate[1];
+
+            case self::SIDE_CODE_CORPS_DIPLOMATIC:
+                if (strlen($licenseplate) > 6)
                 {
-                    return 'CD-' . substr($licenseplate, 2, 2) . "-" . substr($licenseplate, 4, 2);
+                    return $licenseplate[0].'-'.substr($licenseplate, 1, 3).'-'.substr($licenseplate, 4);
                 }
+                return $licenseplate[0].'-'.substr($licenseplate, 1, 2).'-'.substr($licenseplate, 3);
 
-            case 'CDJ':
-                return 'CDJ-' . substr($licenseplate, 3);
+            case self::SIDE_CODE_AMERICAN_FORCES:
 
-            case 'AA':
-                return 'AA-' . substr($licenseplate, 2);
+                $number_matches = array();
+                preg_match('/\d/', $licenseplate, $number_matches, PREG_OFFSET_CAPTURE);
+                $first_number_index = $number_matches[0][1];
 
-            case 7:
-            case 9:
-                // XX-XXX-X
-                return substr($licenseplate, 0, 2) . '-' . substr($licenseplate, 2, 3) .'-' . substr($licenseplate, 5, 1);
-
-            case 8:
-            case 10:
-                // X-XXX-XX
-                return substr($licenseplate, 0, 1) . '-' . substr($licenseplate, 1, 3) . '-' . substr($licenseplate, 4, 2);
-
-            case 11:
-            case 14:
-                // XXX-XX-X
-                return substr($licenseplate, 0, 3) . '-' . substr($licenseplate, 3, 2) . '-' . substr($licenseplate, 5, 1);
-
-            case 12:
-            case 13:
-                // X-XX-XXX
-                return substr($licenseplate, 0, 1) . '-' . substr($licenseplate, 1, 2) . '-' . substr($licenseplate, 3, 3);
+                return substr($licenseplate, 0,2).' '.substr($licenseplate, 2, $first_number_index-2).' '. substr($licenseplate, $first_number_index);
 
             default:
-                // Sidecodes 1-6: XX-XX-XX
-                return substr($licenseplate, 0, 2) . '-' . substr($licenseplate, 2, 2) . '-' . substr($licenseplate, 4, 2);
-        }*/
+                // Sidecodes without any known format
+                return $this->licenseplate;
+        }
     }
 
     /**

--- a/src/Intrepidity/LicensePlate/IsraeliLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/IsraeliLicensePlate.php
@@ -66,4 +66,14 @@ class IsraeliLicensePlate extends AbstractLicensePlate implements LicensePlateIn
                 break;
         }
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'IL';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'ISR';
+    }
 }

--- a/src/Intrepidity/LicensePlate/LicensePlateInterface.php
+++ b/src/Intrepidity/LicensePlate/LicensePlateInterface.php
@@ -5,4 +5,7 @@ interface LicensePlateInterface
 {
     public function format();
     public function isValid();
+    /** Country codes as per https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes */
+    public function getTwoLetterISO();
+    public function getThreeLetterISO();
 }

--- a/src/Intrepidity/LicensePlate/LuxembourgianLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/LuxembourgianLicensePlate.php
@@ -75,4 +75,14 @@ class LuxembourgianLicensePlate extends AbstractLicensePlate implements LicenseP
     {
         return $this->getSidecode() != false;
     }
+
+    public function getTwoLetterISO()
+    {
+        return 'LU';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'LUX';
+    }
 }

--- a/src/Intrepidity/LicensePlate/UKLicensePlate.php
+++ b/src/Intrepidity/LicensePlate/UKLicensePlate.php
@@ -111,4 +111,15 @@ class UKLicensePlate extends AbstractLicensePlate implements LicensePlateInterfa
     {
         return $this->getSidecode() != false;
     }
+
+    /** Country codes as per https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes */
+    public function getTwoLetterISO()
+    {
+        return 'GB';
+    }
+
+    public function getThreeLetterISO()
+    {
+        return 'GBR';
+    }
 }

--- a/tests/GermanLicensePlateFormatTest.php
+++ b/tests/GermanLicensePlateFormatTest.php
@@ -1,0 +1,223 @@
+<?php
+use Intrepidity\LicensePlate\GermanLicensePlate;
+
+class GermanLicensePlateFormatTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDefaultFormat()
+    {
+        //test magical license plate formatting #1
+        $licenseplate = new GermanLicensePlate('aaaa900');
+        $this->assertEquals('AA AA 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test magical license plate formatting #2 (priority to smallest district)
+        $licenseplate = new GermanLicensePlate('aaa900');
+        $this->assertEquals('A AA 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test respecting given format with space
+        $licenseplate = new GermanLicensePlate('aa n900');
+        $this->assertEquals('AA N 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test respecting given format with dash
+        $licenseplate = new GermanLicensePlate('aa-n900');
+        $this->assertEquals('AA N 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test not respecting given format with dash but incorrect format
+        $licenseplate = new GermanLicensePlate('aan 900');
+        $this->assertEquals('A AN 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        $licenseplate = new GermanLicensePlate('a an900');
+        $this->assertEquals('A AN 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        $licenseplate = new GermanLicensePlate('a-an900');
+        $this->assertEquals('A AN 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        $licenseplate = new GermanLicensePlate('a aaa900');
+        $this->assertEquals('AA AA 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test 3 letter district, just to be sure
+        $licenseplate = new GermanLicensePlate('noh a900');
+        $this->assertEquals('NOH A 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+        //test 3 letter district with magical formatting, picks the smallest which in this case is still NOH
+        $licenseplate = new GermanLicensePlate('noha900');
+        $this->assertEquals('NOH A 900', $licenseplate->format(GermanLicensePlate::SIDE_CODE_DEFAULT));
+
+    }
+
+    public function testElectricFormat()
+    {
+        $licenseplate = new GermanLicensePlate('bnel269e');
+        $this->assertEquals('BN EL 269E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('bnel269E');
+        $this->assertEquals('BN EL 269E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('BNEL269E');
+        $this->assertEquals('BN EL 269E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('sb ac 23e');
+        $this->assertEquals('SB AC 23E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('m zx 726e');
+        $this->assertEquals('M ZX 726E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('b ge 6900e');
+        $this->assertEquals('B GE 6900E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+
+        $licenseplate = new GermanLicensePlate('li fi 21e');
+        $this->assertEquals('LI FI 21E', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ELECTRICAL));
+    }
+
+    public function testHistoricalFormat()
+    {
+        $licenseplate = new GermanLicensePlate('e ra 55h');
+        $this->assertEquals('E RA 55H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        $licenseplate = new GermanLicensePlate('e ra 55H');
+        $this->assertEquals('E RA 55H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        $licenseplate = new GermanLicensePlate('wes q 501h');
+        $this->assertEquals('WES Q 501H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        $licenseplate = new GermanLicensePlate('re mb 848h');
+        $this->assertEquals('RE MB 848H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        $licenseplate = new GermanLicensePlate('me nb 7h');
+        $this->assertEquals('ME NB 7H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        //test random WITH giving uppercase and correct format
+        $licenseplate = new GermanLicensePlate('ME NB 7H');
+        $this->assertEquals('ME NB 7H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        //test random WITH giving uppercase and correct format, just with dashes instead of spaces
+        $licenseplate = new GermanLicensePlate('ME-NB-7H');
+        $this->assertEquals('ME NB 7H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+
+        $licenseplate = new GermanLicensePlate('mk b 260h');
+        $this->assertEquals('MK B 260H', $licenseplate->format(GermanLicensePlate::SIDE_CODE_HISTORICAL));
+    }
+
+    public function testPoliticalHeadsFormat()
+    {
+        $licenseplate = new GermanLicensePlate('0-1');
+        $this->assertEquals('0-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('0 1');
+        $this->assertEquals('0-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('01');
+        $this->assertEquals('0-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('02');
+        $this->assertEquals('0-2', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('03');
+        $this->assertEquals('0-3', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('04');
+        $this->assertEquals('0-4', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+
+        $licenseplate = new GermanLicensePlate('11');
+        $this->assertEquals('1-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS));
+    }
+
+    public function testCorpsDiplomaticFormat()
+    {
+        $licenseplate = new GermanLicensePlate('04422');
+        $this->assertEquals('0-44-22', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 100 100');
+        $this->assertEquals('0-100-100', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0-17-112');
+        $this->assertEquals('0-17-112', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 17 112');
+        $this->assertEquals('0-17-112', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 17 175');
+        $this->assertEquals('0-17-175', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 59 114');
+        $this->assertEquals('0-59-114', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        //no way we could now this should be 0-166-1 instead of 0-16-61
+        $licenseplate = new GermanLicensePlate('01661');
+        $this->assertEquals('0-16-61', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 166-1');
+        $this->assertEquals('0-166-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 158 1');
+        $this->assertEquals('0-158-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 100 9');
+        $this->assertEquals('0-100-9', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+
+        $licenseplate = new GermanLicensePlate('0 110 1');
+        $this->assertEquals('0-110-1', $licenseplate->format(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC));
+    }
+
+    public function testAmericanForcesFormat()
+    {
+        $licenseplate = new GermanLicensePlate('IFAG238');
+        $this->assertEquals('IF AG 238', $licenseplate->format(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES));
+
+        $licenseplate = new GermanLicensePlate('HKML266');
+        $this->assertEquals('HK ML 266', $licenseplate->format(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES));
+
+        $licenseplate = new GermanLicensePlate('AFAJ952');
+        $this->assertEquals('AF AJ 952', $licenseplate->format(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES));
+
+        $licenseplate = new GermanLicensePlate('ADDV991');
+        $this->assertEquals('AD DV 991', $licenseplate->format(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES));
+    }
+
+    public function testFederalPoliceFormat()
+    {
+        $licenseplate = new GermanLicensePlate('BP12345');
+        $this->assertEquals('BP 12-345', $licenseplate->format(GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE));
+
+        $licenseplate = new GermanLicensePlate('BP 12345');
+        $this->assertEquals('BP 12-345', $licenseplate->format(GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE));
+
+        $licenseplate = new GermanLicensePlate('BG12345');
+        $this->assertEquals('BG 12-345', $licenseplate->format(GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE));
+    }
+
+    public function testTechnicalReliefFormat()
+    {
+        $licenseplate = new GermanLicensePlate('THW80832');
+        $this->assertEquals('THW 80832', $licenseplate->format(GermanLicensePlate::SIDE_CODE_TECHNICAL_RELIEF));
+
+        $licenseplate = new GermanLicensePlate('THW8207');
+        $this->assertEquals('THW 8207', $licenseplate->format(GermanLicensePlate::SIDE_CODE_TECHNICAL_RELIEF));
+    }
+
+    public function testArmyFormat()
+    {
+        $licenseplate = new GermanLicensePlate('Y127508');
+        $this->assertEquals('Y-127 508', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ARMY));
+
+        $licenseplate = new GermanLicensePlate('Y401664');
+        $this->assertEquals('Y-401 664', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ARMY));
+
+        $licenseplate = new GermanLicensePlate('Y85129');
+        $this->assertEquals('Y-85 129', $licenseplate->format(GermanLicensePlate::SIDE_CODE_ARMY));
+    }
+
+    public function testNatoFormat()
+    {
+        $licenseplate = new GermanLicensePlate('X1234');
+        $this->assertEquals('X-1234', $licenseplate->format(GermanLicensePlate::SIDE_CODE_NATO));
+
+        $licenseplate = new GermanLicensePlate('x1234');
+        $this->assertEquals('X-1234', $licenseplate->format(GermanLicensePlate::SIDE_CODE_NATO));
+
+        $licenseplate = new GermanLicensePlate('x 1234');
+        $this->assertEquals('X-1234', $licenseplate->format(GermanLicensePlate::SIDE_CODE_NATO));
+
+        $licenseplate = new GermanLicensePlate('          x            1234         ');
+        $this->assertEquals('X-1234', $licenseplate->format(GermanLicensePlate::SIDE_CODE_NATO));
+    }
+}

--- a/tests/GermanLicensePlateSidecodeTest.php
+++ b/tests/GermanLicensePlateSidecodeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Intrepidity\LicensePlate\GermanLicensePlate;
+
+class GermanLicensePlateSidecodeTest extends PHPUnit_Framework_TestCase
+{
+    public function testDistricts()
+    {
+        $licenseplate = new GermanLicensePlate('AANL900');
+        $this->assertEquals($licenseplate->getSidecode(), 1);
+        $this->assertTrue($licenseplate->isValid());
+
+
+        $licenseplate = new GermanLicensePlate('BBX900');
+        $this->assertEquals($licenseplate->getSidecode(), 1);
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeP()
+    {
+        $licenseplate = new GermanLicensePlate('01');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('11');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('02');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('03');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('04');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeCD()
+    {
+        $licenseplate = new GermanLicensePlate('04422');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('01337');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('0133713');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeAF()
+    {
+        $licenseplate = new GermanLicensePlate('ADVD1234');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('AFG123');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('HKA1');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('IFAG238');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeAG()
+    {
+        $licenseplate = new GermanLicensePlate('AGIR1337');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('AGA9');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT);
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeBG()
+    {
+        $licenseplate = new GermanLicensePlate('BG137');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE);
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('BP133701');
+        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE);
+        $this->assertTrue($licenseplate->isValid());
+    }
+}

--- a/tests/GermanLicensePlateSidecodeTest.php
+++ b/tests/GermanLicensePlateSidecodeTest.php
@@ -7,91 +7,154 @@ class GermanLicensePlateSidecodeTest extends PHPUnit_Framework_TestCase
     public function testDistricts()
     {
         $licenseplate = new GermanLicensePlate('AANL900');
-        $this->assertEquals($licenseplate->getSidecode(), 1);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_DEFAULT, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
 
         $licenseplate = new GermanLicensePlate('BBX900');
-        $this->assertEquals($licenseplate->getSidecode(), 1);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_DEFAULT, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeE()
+    {
+        $licenseplate = new GermanLicensePlate('bnel269e');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ELECTRICAL, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('sb ac 23e');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ELECTRICAL, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('m zx 726e');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ELECTRICAL, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeH()
+    {
+        $licenseplate = new GermanLicensePlate('e ra 55h');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_HISTORICAL, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('wes q 501h');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_HISTORICAL, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('mk b 260h');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_HISTORICAL, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 
     public function testSidecodeP()
     {
         $licenseplate = new GermanLicensePlate('01');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('11');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('02');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('03');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('04');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_POLITICAL_HEADS, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 
     public function testSidecodeCD()
     {
         $licenseplate = new GermanLicensePlate('04422');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('01337');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('0133713');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_CORPS_DIPLOMATIC, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 
     public function testSidecodeAF()
     {
         $licenseplate = new GermanLicensePlate('ADVD1234');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('AFG123');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('HKA1');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('IFAG238');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_AMERICAN_FORCES, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 
     public function testSidecodeAG()
     {
         $licenseplate = new GermanLicensePlate('AGIR1337');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('AGA9');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_SPECIAL_TRANSPORT, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 
     public function testSidecodeBG()
     {
         $licenseplate = new GermanLicensePlate('BG137');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
 
         $licenseplate = new GermanLicensePlate('BP133701');
-        $this->assertEquals($licenseplate->getSidecode(), GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE);
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_FEDERAL_POLICE, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeTHW()
+    {
+        $licenseplate = new GermanLicensePlate('THW80832');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_TECHNICAL_RELIEF, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('THW8207');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_TECHNICAL_RELIEF, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeY()
+    {
+        $licenseplate = new GermanLicensePlate('Y127508');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ARMY, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('Y401664');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ARMY, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+
+        $licenseplate = new GermanLicensePlate('Y85129');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_ARMY, $licenseplate->getSidecode());
+        $this->assertTrue($licenseplate->isValid());
+    }
+
+    public function testSidecodeX()
+    {
+        $licenseplate = new GermanLicensePlate('X1234');
+        $this->assertEquals(GermanLicensePlate::SIDE_CODE_NATO, $licenseplate->getSidecode());
         $this->assertTrue($licenseplate->isValid());
     }
 }


### PR DESCRIPTION
This PR adds german license plate validation.

# TODOs
* ~Find more reference material on how to format the license plates~
* ~Add formatting for more side codes~
* ~Find out options to the false positives of district formatting. [AAB1337 could be district A as well as AA](https://regex101.com/r/PvG5GS/3).~ formatting is now based on the input string (with spaces and dashes if entered), if the input string is without spaces or dashes it uses the district with the least amount of characters - which should be the largest and therefore has the highest chance to be right.
* ~Finish validation test~
* ~Create formatting test~